### PR TITLE
Add CrowdSec middleware to WordPress Traefik configuration

### DIFF
--- a/docker/wordpress/docker-compose.yaml
+++ b/docker/wordpress/docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       - "traefik.http.services.wordpress.loadbalancer.passhostheader=true"
       - "traefik.http.routers.wordpress.middlewares=compresstraefik"
       - "traefik.http.middlewares.compresstraefik.compress=true"
+      - "traefik.http.routers.wordpress.middlewares=crowdsec@file"
       - "traefik.docker.network=proxy"
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Integrate CrowdSec middleware into the Traefik configuration for WordPress to enhance security measures.